### PR TITLE
Upgrade support platform version to 2024.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ pluginRepositoryUrl=https://github.com/Ivy-Apps/compose-hammer
 pluginVersion=2023.10.11
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
-pluginUntilBuild=232.*
+pluginUntilBuild=241.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2022.2.5
+platformVersion=2024.1.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=com.intellij.java


### PR DESCRIPTION
### Change
  - Upgrade support platform version to 2024.1.1

### Preview
  Plugins now can be run at Android Studio Jellyfish (2023.3.1)
 
<img width="1277" alt="SCR-20240518-iowo" src="https://github.com/Ivy-Apps/compose-hammer/assets/4803452/a02fa011-d334-4ed9-b442-53fe07141d9b">

### Zip

You can grab zip file yourself for testing purpose:
[Zip files](https://github.com/YuanLiou/compose-hammer-ce/releases/tag/0.1)
