### PR TITLE
Upgrade support platform version to 2024.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ pluginRepositoryUrl=https://github.com/Ivy-Apps/compose-hammer
 pluginVersion=2023.10.11
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
-pluginUntilBuild=241.*
+pluginUntilBuild=242.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2024.1.1
+platformVersion=2024.2.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=com.intellij.java


### PR DESCRIPTION
### Change
  - Upgrade support platform version to 2024.2.1

### Preview
  Plugins now can be run at Android Studio Ladybug (2024.2.1), which is a canary version
 
<img width="1728" alt="SCR-20240830-mter" src="https://github.com/user-attachments/assets/b5abf636-71f1-4b87-96d6-a1a1f3ab7dde">


### Zip

You can grab zip file for testing:
[Zip files](https://github.com/YuanLiou/compose-hammer-ce/releases/tag/0.2)
